### PR TITLE
Suppress AuditLogIndex entirely using special values "/dev/null" or "NUL"

### DIFF
--- a/etc/ironbee.conf.example
+++ b/etc/ironbee.conf.example
@@ -29,6 +29,9 @@ Set parser "htp"
 
 # Enable audit engine
 AuditEngine RelevantOnly
+# Set AuditLogIndex to the special value "/dev/null" or "NUL" to suppress
+# the index file entirely.
+# Default: ironbee-index.log
 AuditLogIndex auditlog.log
 AuditLogBaseDir /tmp/ironbee
 AuditLogSubDirFormat "%Y%m%d-%H%M"


### PR DESCRIPTION
**Feature**
Specifying an `AuditLogIndex` value of "/dev/null" or "NUL" (hello Windows!) will suppress opening/creation of the audit log index entirely.

**Changes**
This patch adds support for the special values mentioned above, suppressing the fopen()ing and audit log index entry writing.  The example ironbee.conf file is updated with comments to reflect this change.

**Rationale**
For a certain sysadmin, the IronBee audit log index is just One More Log File to Rotate (tm).  The filesystem itself and mtimes let us reconstruct what the index would have been, and _inotify_ or even a regular `stat(2)` can provide notification if needed.
