### PR TITLE
autoconf/build: Fix broken configuring of ossp-uuid.

### DIFF
--- a/acinclude/ossp-uuid.m4
+++ b/acinclude/ossp-uuid.m4
@@ -16,67 +16,33 @@ OSSP_UUID_LIBS=""
 AC_DEFUN([CHECK_OSSP_UUID],
 [dnl
 
-AC_ARG_WITH(
-    ossp-uuid,
-    [AC_HELP_STRING([--with-ossp-uuid=PATH],[Path to ossp-uuid prefix or script])],
-    [test_paths="${with_ossp_uuid}"],
-    [test_paths="/usr/local /opt/local /opt /usr"])
+AC_ARG_WITH(uuid_config,
+            [  --with-uuid-config=PATH  Path to uuid-config directory],
+            [with_uuid_config="$withval"],
+            [with_uuid_config="no"])
 
-AC_MSG_CHECKING([for ossp-uuid])
-
-for x in ${test_paths}; do
-    dnl # Determine if the script was specified and use it directly
-    if test ! -d "$x" -a -e "$x"; then
-        OSSP_UUID=$x
-        ossp_uuid_path=no
-        break
-    fi
-
-    dnl # Try known config script names/locations
-    for OSSP_UUID in uuid-config; do
-        if test -e "${x}/sbin/${OSSP_UUID}"; then
-            ossp_uuid_path="${x}/sbin"
-            break
-        elif test -e "${x}/bin/${OSSP_UUID}"; then
-            ossp_uuid_path="${x}/bin"
-            break
-        elif test -e "${x}/${OSSP_UUID}"; then
-            ossp_uuid_path="${x}"
-            break
-        else
-            ossp_uuid_path=""
-        fi
-    done
-    if test -n "$ossp_uuid_path"; then
-        break
-    fi
-done
-
-if test -n "${ossp_uuid_path}"; then
-    if test "${ossp_uuid_path}" != "no"; then
-        OSSP_UUID="${ossp_uuid_path}/${OSSP_UUID}"
-    fi
-    AC_MSG_RESULT([${OSSP_UUID}])
-    OSSP_UUID_CFLAGS=`${OSSP_UUID} --cflags`
-    if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(ossp-uuid CFLAGS: $OSSP_UUID_CFLAGS); fi
-    OSSP_UUID_LDFLAGS=`${OSSP_UUID} --ldflags`
-    if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(ossp-uuid LDFLAGS: $OSSP_UUID_LDFLAGS); fi
-    OSSP_UUID_LIBS=`${OSSP_UUID} --libs`
-    if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(ossp-uuid LIBS: $OSSP_UUID_LIBS); fi
+if test "$with_uuid_config" = "no"; then
+   with_uuid_config=$PATH
+   uuid_config_specified="no"
 else
-    AC_MSG_RESULT([no])
+   uuid_config_specified="yes"
 fi
 
-AC_SUBST(OSSP_UUID)
+AC_PATH_PROG(UUID_CONFIG, uuid-config, no, $with_uuid_config)
+if test "$UUID_CONFIG" = "no"; then
+    if test "$uuid_config_specified" = "yes"; then
+        AC_MSG_ERROR([The path specified for uuid-config doesn't seem to contain the program uuid-config.  Please re-check the supplied path."])
+    else
+        AC_MSG_ERROR([Please install ossp-uuid.  If you have ossp-uuid installed in a non-standard location, please specify a path to uuid-config using --with-uuid-config=PATH."])
+    fi
+fi
+
+OSSP_UUID_CFLAGS=`${UUID_CONFIG} --cflags`
+OSSP_UUID_LDFLAGS=`${UUID_CONFIG} --ldflags`
+OSSP_UUID_LIBS=`${UUID_CONFIG} --libs`
+
 AC_SUBST(OSSP_UUID_CFLAGS)
 AC_SUBST(OSSP_UUID_LDFLAGS)
 AC_SUBST(OSSP_UUID_LIBS)
-
-if test -z "${ossp_uuid_path}"; then
-    AC_MSG_NOTICE([*** ossp-uuid utility not found.])
-    ifelse([$2], , AC_MSG_ERROR([ossp-uuid library is required]), $2)
-else
-    AC_MSG_NOTICE([using ossp-uuid ${OSSP_UUID}])
-    ifelse([$1], , , $1) 
-fi 
-])
+]
+)


### PR DESCRIPTION
Previously on not specifying a path for uuid-config, ironbee would search
a fixed set of locations for uuid-config, rather than checking $PATH.  On
specifying a path using --with-ossp-uuid, it would trial by trying to
locate it within "sbin", "bin" under the directory specified by the user.

This has been fixed now.

--with-ossp-uuid has now been changed to --with-uuid-config, which now
expects a path to the directory containing the uuid-config binary.

Likewise, not specifying a path using --with-uuid-config, would make
configure search the $PATH variable.
