### PR TITLE
Fix ib_strstr to actually work correctly when the haystack is smaller than the needle

### DIFF
--- a/util/string.c
+++ b/util/string.c
@@ -275,7 +275,8 @@ const char *ib_strstr(
 
     /* If either pointer is NULL or either length is zero, done */
     if ( (haystack == NULL) || (haystack_len == 0) ||
-         (needle == NULL) || (needle_len == 0) )
+         (needle == NULL) || (needle_len == 0) ||
+         (haystack_len < needle_len) )
     {
         return NULL;
     }


### PR DESCRIPTION
There is a bug here wherein, if the haystack is smaller than the needle (strlen), then imax will get set to the 2's complement of the negative number and this function will wander through a large amount of system ram byte by byte until it will (probably) match whatever you are looking for anyway and return NULL.

TL;DR: Without this check, you end up with a buffer overflow and an incorrect return value.
